### PR TITLE
feat(signup): add HTML skeleton and css styling

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -424,7 +424,8 @@ pages
 
 .books,
 .book,
-.signin {
+.signin,
+.signup {
     --body-grid-gap: 0;
 
     main {
@@ -598,11 +599,12 @@ book
 
 /*
 ********************************************************************************
-Sign in
+Sign in / Sign up
 ********************************************************************************
 */
 
-.signin-section {
+.signin-section,
+.signup-section {
     display: grid;
     grid-template-columns: 1fr 1fr;
     margin: 0;
@@ -622,7 +624,7 @@ Sign in
         flex-direction: column;
         gap: 3.2rem;
         padding-inline: 15rem 23.7rem;
-        padding-top: 20rem;
+        padding-top: 13rem;
     }
 
     label {

--- a/views/signup.php
+++ b/views/signup.php
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sign up</title>
+
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="icon" href="/img/tt.svg" />
+</head>
+
+<body class="signup">
+    <header>
+        <h1>
+            <a href="/">
+                <img src="/img/logo.svg" alt="logo">
+            </a>
+        </h1>
+        <nav>
+            <ul class="header-menu">
+                <li>
+                    <a href="/">Accueil</a>
+                </li>
+                <li>
+                    <a href="/books">Nos livres à l'échange</a>
+                </li>
+                <li>
+                    <a class="header-chat" href="/chat">Messagerie <span class="header-chat-notification">1</span></a>
+                </li>
+                <li>
+                    <a href="/account">Mon compte</a>
+                </li>
+                <li>
+                    <a href="/signin">Connexion</a>
+                </li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <section class="signup-section">
+            <form action="/signup" method="POST">
+                <h2>Connexion</h2>
+                <label for="email">
+                    Addresse e-mail
+                    <input type="email" name="email" id="email">
+                </label>
+                <label for="password">
+                    Mot de passe
+                    <input type="password" name="password" id="password">
+                </label>
+                <button class="btn" href="#">Se connecter</button>
+
+                <span>Pas de compte ? <a href="/signup">Inscrivez-vous</a></span>
+            </form>
+
+            <img src="/img/sign-in-up.jpg" alt="signin image">
+        </section>
+    </main>
+    <footer class="footer">
+        <nav>
+            <ul class="footer-menu">
+                <li><a>Politique de confidentialité</a></li>
+                <li><a>Mentions légales</a></li>
+                <li><a>Tom Troc &copy;</a></li>
+                <li>
+                    <a>
+                        <img src="/img/tt.svg" alt="logo">
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    </footer>
+</body>
+
+</html>


### PR DESCRIPTION
## Description

Add HTML skeleton and CSS styles for the `signup` page following the design defined in Figma.

## Changes made


- [X] clones the `signin` page and change `signin-*` references with `signup-*`
- [X] uses the same styling as `signin-section` but scope it as `signup-section`
- [X] fix `form` padding top size to follow Figma guidelines